### PR TITLE
Update Gulp tasks to copy fonts over to dist/

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,6 +176,12 @@ gulp.task('copy', function() {
     .pipe(gulp.dest(bases.dist))
     .pipe(reload({stream:true}));
 
+  // copy fonts to dist directly
+  gulp.src([bases.app + 'fonts/*'])
+    .pipe(size({ gzip: true, showFiles: true }))
+    .pipe(gulp.dest(bases.dist + 'fonts/'))
+    .pipe(reload({stream:true}));
+
 });
 
 gulp.task('sass-lint', function() {


### PR DESCRIPTION
Update the existing `copy` task, to include moving the fonts directory from `src/` to `dist/` (and closes #11).